### PR TITLE
alterada-regra-consulta-concessoes

### DIFF
--- a/ControleDeMateriais.Api/Controllers/MaterialsLoanController.cs
+++ b/ControleDeMateriais.Api/Controllers/MaterialsLoanController.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace ControleDeMateriais.Api.Controllers;
 
 [ServiceFilter(typeof(AuthenticatedUserAttribute))]
-public class MaterialsLoan : ControleDeMateriaisController
+public class MaterialsLoanController : ControleDeMateriaisController
 {
     [HttpGet]
     [ProducesResponseType(typeof(ResponseBorrowedMaterialJson), StatusCodes.Status200OK)]
@@ -42,7 +42,7 @@ public class MaterialsLoan : ControleDeMateriaisController
     }
 
     [HttpGet]
-    [Route("status/{status}")]
+    [Route("confirmed/{status}")]
     [ProducesResponseType(typeof(ResponseBorrowedMaterialJson), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]

--- a/ControleDeMateriais.Api/Controllers/MaterialsReturnController.cs
+++ b/ControleDeMateriais.Api/Controllers/MaterialsReturnController.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace ControleDeMateriais.Api.Controllers;
 
 [ServiceFilter(typeof(AuthenticatedUserAttribute))]
-public class MaterialsReturn : ControleDeMateriaisController
+public class MaterialsReturnController : ControleDeMateriaisController
 {
     [HttpPost]
     [ProducesResponseType(StatusCodes.Status200OK)]

--- a/ControleDeMateriais.Application/UseCases/MaterialsLoan/Confirm/ConfirmSelectedMaterialUseCase.cs
+++ b/ControleDeMateriais.Application/UseCases/MaterialsLoan/Confirm/ConfirmSelectedMaterialUseCase.cs
@@ -46,6 +46,12 @@ public class ConfirmSelectedMaterialUseCase : IConfirmSelectedMaterialUseCase
 
         var collaborator = await _confirmPasswordCollaboratorUseCase.Execute(request.Enrollment, encryptedPassword);
 
+        var loanConfirmed = await _repositoryMaterialForCollaboratorReadOnly.RecoverByCollaboratorLoanStatus(
+                                                                        new MongoDB.Bson.ObjectId(collaborator.Id), true);
+
+        if (loanConfirmed.Any())
+            throw new ExceptionValidationErrors(new List<string> { ErrorMessagesResource.CONCESSAO_JA_CONFIRMADA });
+
         return collaborator;
     }
 }

--- a/ControleDeMateriais.Application/UseCases/MaterialsLoan/Recover/RecoverBorrowedMaterialUseCase.cs
+++ b/ControleDeMateriais.Application/UseCases/MaterialsLoan/Recover/RecoverBorrowedMaterialUseCase.cs
@@ -62,6 +62,7 @@ public class RecoverBorrowedMaterialUseCase : IRecoverBorrowedMaterialUseCase
                 LoanDateTime = materialForCollaborator.DateTimeConfirmation,
                 ColaboratorNicknameConfirmed = collaboratorConfirm?.Nickname,
                 ListMaterialBorrowed = resultListMaterials,
+                HashIdLoan = materialForCollaborator.MaterialsHashId,
             });
         }
 
@@ -75,12 +76,12 @@ public class RecoverBorrowedMaterialUseCase : IRecoverBorrowedMaterialUseCase
         var collaborator = await _repositoryCollaboratorReadOnly.RecoverByEnrollment(enrollment) ??
             throw new ExceptionValidationErrors(new List<string> { ErrorMessagesResource.COLABORADOR_NAO_LOCALIZADO });
 
-        var materialsForCollaborator = await _repositoryMaterialForCollaboratorReadOnly.RecoverByCollaborator(collaborator.Id);
+        var materialsForCollaborator = await _repositoryMaterialForCollaboratorReadOnly.RecoverByCollaboratorLoanStatus(collaborator.Id, status);
 
         foreach (var materialForCollaborator in materialsForCollaborator)
         {
             var resultBorrowedMaterials = await _repositoryBorrowedMaterialReadOnly
-                .RecoverByHashIdAndStatus(materialForCollaborator.MaterialsHashId, status);
+                .RecoverByHashId(materialForCollaborator.MaterialsHashId);
 
             if (!resultBorrowedMaterials.Any())
             {
@@ -102,6 +103,7 @@ public class RecoverBorrowedMaterialUseCase : IRecoverBorrowedMaterialUseCase
                 LoanDateTime = materialForCollaborator.DateTimeConfirmation,
                 ColaboratorNicknameConfirmed = collaboratorConfirm?.Nickname,
                 ListMaterialBorrowed = resultListMaterials,
+                HashIdLoan = materialForCollaborator.MaterialsHashId,
             });
         }
 
@@ -112,12 +114,12 @@ public class RecoverBorrowedMaterialUseCase : IRecoverBorrowedMaterialUseCase
     {
         var result = new List<ResponseBorrowedMaterialJson>();
 
-        var materialsForCollaborator = await _repositoryMaterialForCollaboratorReadOnly.RecoverAll();
+        var materialsForCollaborator = await _repositoryMaterialForCollaboratorReadOnly.RecoverByStatus(status);
 
         foreach (var materialForCollaborator in materialsForCollaborator)
         {
             var resultBorrowedMaterials = await _repositoryBorrowedMaterialReadOnly
-                .RecoverByHashIdAndStatus(materialForCollaborator.MaterialsHashId, status);
+                .RecoverByHashId(materialForCollaborator.MaterialsHashId);
 
             if (!resultBorrowedMaterials.Any())
             {
@@ -140,6 +142,7 @@ public class RecoverBorrowedMaterialUseCase : IRecoverBorrowedMaterialUseCase
                 LoanDateTime = materialForCollaborator.DateTimeConfirmation,
                 ColaboratorNicknameConfirmed = collaboratorConfirm?.Nickname,
                 ListMaterialBorrowed = resultListMaterials,
+                HashIdLoan = materialForCollaborator.MaterialsHashId,
             });
         }
 
@@ -179,6 +182,7 @@ public class RecoverBorrowedMaterialUseCase : IRecoverBorrowedMaterialUseCase
                 LoanDateTime = materialForCollaborator.DateTimeConfirmation,
                 ColaboratorNicknameConfirmed = collaboratorConfirm?.Nickname,
                 ListMaterialBorrowed = resultListMaterials,
+                HashIdLoan = materialForCollaborator.MaterialsHashId,
             });
         }
 
@@ -222,6 +226,7 @@ public class RecoverBorrowedMaterialUseCase : IRecoverBorrowedMaterialUseCase
 
         return resultListMaterials;
     }
+    
     private async Task<List<ResponseBorrowedListMaterialJson>> AddMaterialInformation(BorrowedMaterial resultBorrowedMaterials)
     {
         var resultListMaterials = new List<ResponseBorrowedListMaterialJson>();

--- a/ControleDeMateriais.Communication/Responses/ResponseBorrowedMaterialJson.cs
+++ b/ControleDeMateriais.Communication/Responses/ResponseBorrowedMaterialJson.cs
@@ -1,6 +1,7 @@
 ﻿namespace ControleDeMateriais.Communication.Responses;
 public class ResponseBorrowedMaterialJson
 {
+    public string HashIdLoan { get; set; }
     public string CollaboratorEnrollment { get; set; }
     public string CollaboratorNickname { get; set; }
     public string CollaboratorTelephone { get; set; }

--- a/ControleDeMateriais.Exceptions/ExceptionBase/ErrorMessagesResource.Designer.cs
+++ b/ControleDeMateriais.Exceptions/ExceptionBase/ErrorMessagesResource.Designer.cs
@@ -151,6 +151,15 @@ namespace ControleDeMateriais.Exceptions.ExceptionBase {
         }
         
         /// <summary>
+        ///   Consulta uma cadeia de caracteres localizada semelhante a Concessão já confirmada..
+        /// </summary>
+        public static string CONCESSAO_JA_CONFIRMADA {
+            get {
+                return ResourceManager.GetString("CONCESSAO_JA_CONFIRMADA", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Consulta uma cadeia de caracteres localizada semelhante a Concessão não confirmada..
         /// </summary>
         public static string CONCESSAO_NAO_CONFIRMADA {

--- a/ControleDeMateriais.Exceptions/ExceptionBase/ErrorMessagesResource.resx
+++ b/ControleDeMateriais.Exceptions/ExceptionBase/ErrorMessagesResource.resx
@@ -147,6 +147,9 @@
   <data name="COLABORADOR_NAO_LOCALIZADO" xml:space="preserve">
     <value>Nenhum colaborador foi localizado com os dados informados.</value>
   </data>
+  <data name="CONCESSAO_JA_CONFIRMADA" xml:space="preserve">
+    <value>Concessão já confirmada.</value>
+  </data>
   <data name="CONCESSAO_NAO_CONFIRMADA" xml:space="preserve">
     <value>Concessão não confirmada.</value>
   </data>

--- a/ControleDeMateriais.Infrastructure/AccessRepository/Repository/CollaboratorRepository.cs
+++ b/ControleDeMateriais.Infrastructure/AccessRepository/Repository/CollaboratorRepository.cs
@@ -29,6 +29,7 @@ public class CollaboratorRepository : ICollaboratorWriteOnlyRepository, ICollabo
 
         return result;
     }
+
     public async Task Delete(string enrollment)
     {
         var collection = ConnectDataBase.GetCollaboratorAccess();

--- a/ControleDeMateriais.Infrastructure/AccessRepository/Repository/MaterialsForCollaboratorRepository.cs
+++ b/ControleDeMateriais.Infrastructure/AccessRepository/Repository/MaterialsForCollaboratorRepository.cs
@@ -43,6 +43,16 @@ public class MaterialsForCollaboratorRepository : IMaterialsForCollaboratorWrite
         return result;
     }
 
+    public async Task<List<MaterialsForCollaborator>> RecoverByCollaboratorLoanStatus(ObjectId id, bool status)
+    {
+        var collection = ConnectDataBase.GetMaterialsForCollaboratorAccess();
+        var filter = Builders<MaterialsForCollaborator>.Filter.Where(c => c.CollaboratorId.Equals(id) &
+                                                            c.Confirmed.Equals(status));
+        var result = await collection.Find(filter).ToListAsync() ?? null;
+
+        return result;
+    }
+
     public async Task<MaterialsForCollaborator> RecoverByHashId(string hashId)
     {
         var collection = ConnectDataBase.GetMaterialsForCollaboratorAccess();
@@ -57,6 +67,15 @@ public class MaterialsForCollaboratorRepository : IMaterialsForCollaboratorWrite
         var collection = ConnectDataBase.GetMaterialsForCollaboratorAccess();
         var filter = Builders<MaterialsForCollaborator>.Filter.And(
             Builders<MaterialsForCollaborator>.Filter.In(c => c.MaterialsHashId, hashId));
+        var result = await collection.Find(filter).ToListAsync() ?? null;
+
+        return result;
+    }
+
+    public async Task<List<MaterialsForCollaborator>> RecoverByStatus(bool status)
+    {
+        var collection = ConnectDataBase.GetMaterialsForCollaboratorAccess();
+        var filter = Builders<MaterialsForCollaborator>.Filter.Where(c => c.Confirmed.Equals(status));
         var result = await collection.Find(filter).ToListAsync() ?? null;
 
         return result;

--- a/ControleDeMaterias.Domain/Repositories/Loan/MaterialForCollaborator/IMaterialForCollaboratorReadOnly.cs
+++ b/ControleDeMaterias.Domain/Repositories/Loan/MaterialForCollaborator/IMaterialForCollaboratorReadOnly.cs
@@ -6,6 +6,8 @@ public interface IMaterialForCollaboratorReadOnly
 {
     Task<List<MaterialsForCollaborator>> RecoverAll();
     Task<List<MaterialsForCollaborator>> RecoverByCollaborator(ObjectId id);
+    Task<List<MaterialsForCollaborator>> RecoverByCollaboratorLoanStatus(ObjectId id, bool status);
+    Task<List<MaterialsForCollaborator>> RecoverByStatus(bool status);
     Task<MaterialsForCollaborator> RecoverByHashId(string hashId);
     Task<List<MaterialsForCollaborator>> RecoverByHashIds(List<string> hashId);
 }


### PR DESCRIPTION
Alterada a regra de negócio para consulta de concessões. Agora as consultas por status são feitas na tabela materialsForCollaborator (tabela forte), e não mais na borrowedMaterils