### PR TITLE
add-funcao-excluir-concessoes

### DIFF
--- a/ControleDeMateriais.Api/Controllers/MaterialLoanController.cs
+++ b/ControleDeMateriais.Api/Controllers/MaterialLoanController.cs
@@ -1,5 +1,6 @@
 using ControleDeMateriais.Api.Filters.LoggedUser;
 using ControleDeMateriais.Application.UseCases.Loan.Confirm;
+using ControleDeMateriais.Application.UseCases.Loan.Delete;
 using ControleDeMateriais.Application.UseCases.Loan.Selection;
 using ControleDeMateriais.Communication.Requests;
 using Microsoft.AspNetCore.Mvc;
@@ -30,6 +31,19 @@ public class MaterialLoanController : ControleDeMateriaisController
         [FromBody] RequestConfirmSelectedMaterialJson request)
     {
         await useCase.Execute(request);
+
+        return Ok();
+    }
+
+    [HttpDelete]
+    [Route("hashId/{hashId}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> Delete(
+        [FromServices] IDeleteLoanUseCase useCase,
+        [FromRoute] string hashId)
+    {
+        await useCase.Execute(hashId);
 
         return Ok();
     }

--- a/ControleDeMateriais.Api/Controllers/MaterialsForCollaboratorController.cs
+++ b/ControleDeMateriais.Api/Controllers/MaterialsForCollaboratorController.cs
@@ -1,5 +1,7 @@
 using ControleDeMateriais.Api.Filters.LoggedUser;
+using ControleDeMateriais.Application.UseCases.Loan.Delete;
 using ControleDeMateriais.Application.UseCases.Loan.Recover;
+using ControleDeMateriais.Application.UseCases.Material.Delete;
 using ControleDeMateriais.Communication.Responses;
 using Microsoft.AspNetCore.Mvc;
 
@@ -72,23 +74,6 @@ public class MaterialsForCollaboratorController : ControleDeMateriaisController
         return NoContent();
     }
 
-    //[HttpGet]
-    //[Route("barCode/{barCode}")]
-    //[ProducesResponseType(typeof(ResponseMaterialForCollaboratorJson), StatusCodes.Status200OK)]
-    //[ProducesResponseType(StatusCodes.Status204NoContent)]
-    //[ProducesResponseType(StatusCodes.Status400BadRequest)]
-    //public async Task<IActionResult> RecoverByBarCode(
-    //    [FromServices] IRecoverMaterialForCollaboratorUseCase useCase,
-    //    [FromRoute] string barCode)
-    //{
-    //    var result = await useCase.Execute(barCode);
-
-    //    if (result.Any())
-    //        return Ok(result);
-
-    //    return NoContent();
-    //}
-
     [HttpGet]
     [Route("date")]
     [ProducesResponseType(typeof(ResponseMaterialForCollaboratorJson), StatusCodes.Status200OK)]
@@ -105,5 +90,5 @@ public class MaterialsForCollaboratorController : ControleDeMateriaisController
             return Ok(result);
 
         return NoContent();
-    }
+    }    
 }

--- a/ControleDeMateriais.Application/Initializer.cs
+++ b/ControleDeMateriais.Application/Initializer.cs
@@ -8,6 +8,7 @@ using ControleDeMateriais.Application.UseCases.Collaborator.Recover;
 using ControleDeMateriais.Application.UseCases.Collaborator.Register;
 using ControleDeMateriais.Application.UseCases.Collaborator.Update;
 using ControleDeMateriais.Application.UseCases.Loan.Confirm;
+using ControleDeMateriais.Application.UseCases.Loan.Delete;
 using ControleDeMateriais.Application.UseCases.Loan.Devolution;
 using ControleDeMateriais.Application.UseCases.Loan.Recover;
 using ControleDeMateriais.Application.UseCases.Loan.Selection;
@@ -86,6 +87,7 @@ public static class Initializer
         services.AddScoped<IRecoverMaterialForCollaboratorUseCase, RecoverMaterialForCollaboratorUseCase>();
         services.AddScoped<IConfirmSelectedMaterialUseCase, ConfirmSelectedMaterialUseCase>();
         services.AddScoped<IMaterialDevolutionUseCase, MaterialDevolutionUseCase>();
+        services.AddScoped<IDeleteLoanUseCase, DeleteLoanUseCase>();
         #endregion
 
         #region BorrowedMaterials

--- a/ControleDeMateriais.Application/Services/AutoMapper/AutoMapperConfiguration.cs
+++ b/ControleDeMateriais.Application/Services/AutoMapper/AutoMapperConfiguration.cs
@@ -62,5 +62,10 @@ public class AutoMapperConfiguration : Profile
             .ForMember(destiny => destiny.UserIdCreated, config => config.MapFrom(origin => origin.UserId));
 
         CreateMap<Domain.Entities.Collaborator, Domain.Entities.CollaboratorDeletionLog>();
+
+        CreateMap<Domain.Entities.BorrowedMaterial, Domain.Entities.BorrowedMaterialDeletionLog>();
+
+        CreateMap<Domain.Entities.MaterialsForCollaborator, Domain.Entities.MaterialsForCollaboratorDeletionLog>()
+            .ForMember(destiny => destiny.UserIdCreated, config => config.MapFrom(origin => origin.UserId));
     }
 }

--- a/ControleDeMateriais.Application/UseCases/Loan/Delete/DeleteLoanUseCase.cs
+++ b/ControleDeMateriais.Application/UseCases/Loan/Delete/DeleteLoanUseCase.cs
@@ -1,0 +1,80 @@
+﻿
+using AutoMapper;
+using ControleDeMateriais.Application.Services.LoggedUser;
+using ControleDeMateriais.Domain.Entities;
+using ControleDeMateriais.Domain.Repositories.Loan.Borrowed;
+using ControleDeMateriais.Domain.Repositories.Loan.MaterialForCollaborator;
+using ControleDeMateriais.Domain.Repositories.Material;
+using ControleDeMateriais.Exceptions.ExceptionBase;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace ControleDeMateriais.Application.UseCases.Loan.Delete;
+public class DeleteLoanUseCase : IDeleteLoanUseCase
+{
+    private readonly IMapper _mapper;
+    private readonly IMaterialsForCollaboratorWriteOnly _repositoryMaterialsForCollaboratorWriteOnly;
+    private readonly IMaterialsForCollaboratorReadOnly _repositoryMaterialsForCollaboratorReadOnly;
+    private readonly IBorrowedMaterialReadOnly _repositoryBorrowedMaterialReadOnly;
+    private readonly IBorrowedMaterialWriteOnly _repositoryBorrowedMaterialWriteOnly;
+    private readonly IMaterialReadOnlyRepository _repositoryMaterialReadOnly;
+    private readonly ILoggedUser _loggedUser;
+
+    public DeleteLoanUseCase(
+        IMapper mapper,
+        IMaterialsForCollaboratorWriteOnly repositoryMaterialsForCollaboratorWriteOnly, 
+        IMaterialsForCollaboratorReadOnly repositoryMaterialsForCollaboratorReadOnly,
+        IBorrowedMaterialWriteOnly repositoryBorrowedMaterialWriteOnly,
+        IBorrowedMaterialReadOnly repositoryBorrowedMaterialReadOnly,
+        IMaterialReadOnlyRepository repositoryMaterialReadOnly,
+        ILoggedUser loggedUser)
+    {
+        _mapper = mapper;
+        _repositoryMaterialsForCollaboratorWriteOnly = repositoryMaterialsForCollaboratorWriteOnly;
+        _repositoryMaterialsForCollaboratorReadOnly = repositoryMaterialsForCollaboratorReadOnly;
+        _repositoryBorrowedMaterialWriteOnly = repositoryBorrowedMaterialWriteOnly;
+        _repositoryBorrowedMaterialReadOnly = repositoryBorrowedMaterialReadOnly;
+        _repositoryMaterialReadOnly = repositoryMaterialReadOnly;
+        _loggedUser = loggedUser;
+    }
+
+    public async Task Execute(string hashId)
+    {
+        var materialForCollaborator =  await ValidateData(hashId);
+        var borrowedMaterials = await _repositoryBorrowedMaterialReadOnly.RecoverByHashId(hashId);
+
+        var user = await _loggedUser.RecoveryUser();
+
+        var borrowedMaterialsLog = _mapper.Map<List<BorrowedMaterialDeletionLog>>(borrowedMaterials);
+
+        for ( var i = 0; i < borrowedMaterialsLog.Count; i++) 
+        {
+            var material = await _repositoryMaterialReadOnly.RecoverByBarCode(borrowedMaterialsLog[i].BarCode);
+            borrowedMaterialsLog[i].MaterialName = material.Name;
+            borrowedMaterialsLog[i].MaterialDescription = material.Description;
+        }
+
+        await _repositoryBorrowedMaterialWriteOnly.RegisterDeletionLog(borrowedMaterialsLog);
+
+        var materialForCollaboratorLog = _mapper.Map<MaterialsForCollaboratorDeletionLog>(materialForCollaborator);
+        materialForCollaboratorLog.UserIdDeleted = user.Id;
+        
+        await _repositoryMaterialsForCollaboratorWriteOnly.RegisterDeletionLog(materialForCollaboratorLog);
+
+        await _repositoryBorrowedMaterialWriteOnly.Delete(hashId);
+
+        await _repositoryMaterialsForCollaboratorWriteOnly.Delete(hashId);
+    }
+
+    private async Task<MaterialsForCollaborator> ValidateData(string hashId)
+    {
+        var materialForCollaborator = await _repositoryMaterialsForCollaboratorReadOnly.RecoverByHashId(hashId) ??
+            throw new ExceptionValidationErrors(new List<string> { ErrorMessagesResource.CONCESSAO_NAO_LOCALIZADA });
+
+        if (materialForCollaborator.Confirmed)
+        {
+            throw new ExceptionValidationErrors(new List<string> { ErrorMessagesResource.EXCLUSAO_CONCESSAO_CONFIRMADA_NAO_PERMITIDA });
+        }
+
+        return materialForCollaborator;
+    }
+}

--- a/ControleDeMateriais.Application/UseCases/Loan/Delete/IDeleteLoanUseCase.cs
+++ b/ControleDeMateriais.Application/UseCases/Loan/Delete/IDeleteLoanUseCase.cs
@@ -1,0 +1,5 @@
+﻿namespace ControleDeMateriais.Application.UseCases.Loan.Delete;
+public interface IDeleteLoanUseCase
+{
+    Task Execute(string hashId);
+}

--- a/ControleDeMateriais.Application/UseCases/Loan/Recover/IRecoverMaterialForCollaboratorUseCase.cs
+++ b/ControleDeMateriais.Application/UseCases/Loan/Recover/IRecoverMaterialForCollaboratorUseCase.cs
@@ -8,5 +8,4 @@ public interface IRecoverMaterialForCollaboratorUseCase
     Task<List<ResponseMaterialForCollaboratorJson>> Execute(bool status);
     Task<List<ResponseMaterialForCollaboratorJson>> Execute(string enrollment);
     Task<List<ResponseMaterialForCollaboratorJson>> Execute(string enrollment, bool status);
-    //teste
 }

--- a/ControleDeMateriais.Exceptions/ExceptionBase/ErrorMessagesResource.Designer.cs
+++ b/ControleDeMateriais.Exceptions/ExceptionBase/ErrorMessagesResource.Designer.cs
@@ -295,6 +295,15 @@ namespace ControleDeMateriais.Exceptions.ExceptionBase {
         }
         
         /// <summary>
+        ///   Consulta uma cadeia de caracteres localizada semelhante a Exclusão de concessão já confirmada não é permitida..
+        /// </summary>
+        public static string EXCLUSAO_CONCESSAO_CONFIRMADA_NAO_PERMITIDA {
+            get {
+                return ResourceManager.GetString("EXCLUSAO_CONCESSAO_CONFIRMADA_NAO_PERMITIDA", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Consulta uma cadeia de caracteres localizada semelhante a Usuário e/ou senha incorretos..
         /// </summary>
         public static string LOGIN_INVALIDO {

--- a/ControleDeMateriais.Exceptions/ExceptionBase/ErrorMessagesResource.resx
+++ b/ControleDeMateriais.Exceptions/ExceptionBase/ErrorMessagesResource.resx
@@ -195,6 +195,9 @@
   <data name="ERRO_DESCONHECIDO" xml:space="preserve">
     <value>Erro desconhecido.</value>
   </data>
+  <data name="EXCLUSAO_CONCESSAO_CONFIRMADA_NAO_PERMITIDA" xml:space="preserve">
+    <value>Exclusão de concessão já confirmada não é permitida.</value>
+  </data>
   <data name="LOGIN_INVALIDO" xml:space="preserve">
     <value>Usuário e/ou senha incorretos.</value>
   </data>

--- a/ControleDeMateriais.Infrastructure/AccessRepository/ConnectDataBase.cs
+++ b/ControleDeMateriais.Infrastructure/AccessRepository/ConnectDataBase.cs
@@ -12,6 +12,8 @@ public class ConnectDataBase
     private const string collaboratorDeletionLog = "collaboratorDeletionLog";
     private const string borrowedMaterial = "borrowedMaterials";
     private const string materialsForCollaborator = "materialsForCollaborator";
+    private const string materialsForCollaboratorDeletionLog = "materialsForCollaboratorDeletionLog";
+    private const string borrowedMaterialsDeletionLog = "borrowedMaterialsDeletionLog";
 
     public static IMongoCollection<User> GetUserAccess()
     {
@@ -114,6 +116,34 @@ public class ConnectDataBase
 
         IMongoCollection<MaterialsForCollaborator> collection = 
             mongoDataBase.GetCollection<MaterialsForCollaborator>(materialsForCollaborator);
+
+        return collection;
+    }
+
+    public static IMongoCollection<MaterialsForCollaboratorDeletionLog> GetMaterialsForCollaboratorDeletionLogAccess()
+    {
+        var connection = Environment.GetEnvironmentVariable("ConnectionString");
+        var databaseName = Environment.GetEnvironmentVariable("DatabaseName");
+
+        var mongoClient = new MongoClient(connection);
+        var mongoDataBase = mongoClient.GetDatabase(databaseName);
+
+        IMongoCollection<MaterialsForCollaboratorDeletionLog> collection = 
+            mongoDataBase.GetCollection<MaterialsForCollaboratorDeletionLog>(materialsForCollaboratorDeletionLog);
+
+        return collection;
+    }
+
+    public static IMongoCollection<BorrowedMaterialDeletionLog> GetBorrowedMaterialsDeletionLogAccess()
+    {
+        var connection = Environment.GetEnvironmentVariable("ConnectionString");
+        var databaseName = Environment.GetEnvironmentVariable("DatabaseName");
+
+        var mongoClient = new MongoClient(connection);
+        var mongoDataBase = mongoClient.GetDatabase(databaseName);
+
+        IMongoCollection<BorrowedMaterialDeletionLog> collection = 
+            mongoDataBase.GetCollection<BorrowedMaterialDeletionLog>(borrowedMaterialsDeletionLog);
 
         return collection;
     }

--- a/ControleDeMateriais.Infrastructure/AccessRepository/Repository/BorrowedRepository.cs
+++ b/ControleDeMateriais.Infrastructure/AccessRepository/Repository/BorrowedRepository.cs
@@ -39,6 +39,19 @@ public class BorrowedRepository : IBorrowedMaterialWriteOnly, IBorrowedMaterialR
 
         await collection.UpdateManyAsync(filter, updateObject);
     }
+    
+    public async Task Delete(string hashId)
+    {
+        var collection = ConnectDataBase.GetBorrowedMaterialAccess();
+        var filter = Builders<BorrowedMaterial>.Filter.Where(c => c.HashId.Equals(hashId));
+        await collection.DeleteManyAsync(filter);
+    }
+
+    public async Task RegisterDeletionLog(List<BorrowedMaterialDeletionLog> borrowedMaterialsLog)
+    {
+        var collection = ConnectDataBase.GetBorrowedMaterialsDeletionLogAccess();
+        await collection.InsertManyAsync(borrowedMaterialsLog);
+    }
 
     public async Task<List<BorrowedMaterial>> RecoverAll()
     {
@@ -117,4 +130,5 @@ public class BorrowedRepository : IBorrowedMaterialWriteOnly, IBorrowedMaterialR
 
         return await collection.Find(filter).ToListAsync();
     }
+
 }

--- a/ControleDeMateriais.Infrastructure/AccessRepository/Repository/MaterialsForCollaboratorRepository.cs
+++ b/ControleDeMateriais.Infrastructure/AccessRepository/Repository/MaterialsForCollaboratorRepository.cs
@@ -25,6 +25,19 @@ public class MaterialsForCollaboratorRepository : IMaterialsForCollaboratorWrite
         await collection.UpdateOneAsync(filter, updateObject);
     }
 
+    public async Task Delete(string hashId)
+    {
+        var collection = ConnectDataBase.GetMaterialsForCollaboratorAccess();
+        var filter = Builders<MaterialsForCollaborator>.Filter.Where(c => c.MaterialsHashId.Equals(hashId));
+        await collection.DeleteOneAsync(filter);
+    }
+
+    public async Task RegisterDeletionLog(MaterialsForCollaboratorDeletionLog materialsForCollaboratorDeletionLog)
+    {
+        var collection = ConnectDataBase.GetMaterialsForCollaboratorDeletionLogAccess();
+        await collection.InsertOneAsync(materialsForCollaboratorDeletionLog);
+    }
+
     public async Task<List<MaterialsForCollaborator>> RecoverAll()
     {
         var collection = ConnectDataBase.GetMaterialsForCollaboratorAccess();

--- a/ControleDeMaterias.Domain/Entities/BorrowedMaterialDeletionLog.cs
+++ b/ControleDeMaterias.Domain/Entities/BorrowedMaterialDeletionLog.cs
@@ -1,0 +1,11 @@
+﻿using MongoDB.Bson;
+
+namespace ControleDeMateriais.Domain.Entities;
+public class BorrowedMaterialDeletionLog : BaseEntity
+{
+    public string HashId { get; set; }
+    public string BarCode { get; set; }
+    public string MaterialName { get; set; }
+    public string MaterialDescription { get; set; }
+    public DateTime DateDeletion { get; set; } = DateTime.UtcNow;
+}

--- a/ControleDeMaterias.Domain/Entities/CollaboratorDeletionLog.cs
+++ b/ControleDeMaterias.Domain/Entities/CollaboratorDeletionLog.cs
@@ -1,7 +1,7 @@
 ﻿using MongoDB.Bson;
 
 namespace ControleDeMateriais.Domain.Entities;
-public class CollaboratorDeletionLog
+public class CollaboratorDeletionLog : BaseEntity
 {
     public string Name { get; set; }
     public string Nickname { get; set; }
@@ -10,4 +10,5 @@ public class CollaboratorDeletionLog
     public string Telephone { get; set; }
     public ObjectId UserIdCreated { get; set; }
     public ObjectId UserIdDeleted { get; set; }
+    public DateTime DateDeletion { get; set; } = DateTime.UtcNow;
 }

--- a/ControleDeMaterias.Domain/Entities/MaterialDeletionLog.cs
+++ b/ControleDeMaterias.Domain/Entities/MaterialDeletionLog.cs
@@ -11,5 +11,6 @@ public class MaterialDeletionLog : BaseEntity
     public Category Category { get; set; }
     public ObjectId UserIdCreated { get; set; }
     public ObjectId UserIdDeleted { get; set; }
+    public DateTime DateDeletion { get; set; } = DateTime.UtcNow;
 }
 

--- a/ControleDeMaterias.Domain/Entities/MaterialsForCollaboratorDeletionLog.cs
+++ b/ControleDeMaterias.Domain/Entities/MaterialsForCollaboratorDeletionLog.cs
@@ -1,0 +1,11 @@
+﻿using MongoDB.Bson;
+
+namespace ControleDeMateriais.Domain.Entities;
+public class MaterialsForCollaboratorDeletionLog : BaseEntity
+{
+    public ObjectId CollaboratorId { get; set; }
+    public string MaterialsHashId { get; set; }
+    public ObjectId UserIdCreated { get; set; }
+    public DateTime DateDeletion { get; set; } = DateTime.UtcNow;
+    public ObjectId UserIdDeleted { get; set; }
+}

--- a/ControleDeMaterias.Domain/Repositories/Loan/Borrowed/IBorrowedMaterialWriteOnly.cs
+++ b/ControleDeMaterias.Domain/Repositories/Loan/Borrowed/IBorrowedMaterialWriteOnly.cs
@@ -7,4 +7,6 @@ public interface IBorrowedMaterialWriteOnly
     Task Add(List<BorrowedMaterial> borrowedMaterial);
     Task Confirm(string hashId);
     Task Devolution(MaterialDevolution materialDevolution);
+    Task Delete(string hashId);
+    Task RegisterDeletionLog(List<BorrowedMaterialDeletionLog> borrowedMaterialsLog);
 }

--- a/ControleDeMaterias.Domain/Repositories/Loan/MaterialForCollaborator/IMaterialsForCollaboratorWriteOnly.cs
+++ b/ControleDeMaterias.Domain/Repositories/Loan/MaterialForCollaborator/IMaterialsForCollaboratorWriteOnly.cs
@@ -5,4 +5,6 @@ public interface IMaterialsForCollaboratorWriteOnly
 {
     Task Add(MaterialsForCollaborator materialsForCollaborator);
     Task Confirm(string hashId, string userId);
+    Task Delete(string hashId);
+    Task RegisterDeletionLog(MaterialsForCollaboratorDeletionLog materialsForCollaboratorDeletionLog);
 }


### PR DESCRIPTION
Add função para excluir concessões. Só é possível excluir uma concessão que não foi confirmada pelo colaborador. Segue toda a regra de registrar os logs referentes a concessão (materialsForCollaborator e borrowedMaterials).